### PR TITLE
After I added a folder that was NOT node_modules, now backend folder …

### DIFF
--- a/backend/folder-that-is-not-node_modules/when-backend-only-had-node_modules-backend-was-ignored.txt
+++ b/backend/folder-that-is-not-node_modules/when-backend-only-had-node_modules-backend-was-ignored.txt
@@ -1,0 +1,2 @@
+when-backend-had-only-node_modules-backend-folder-was-ignored.txt
+


### PR DESCRIPTION
…is committed.  Before when the only thing under backend was node_modules, the .gitignore said that backend was not needed.